### PR TITLE
fix: Made MTBStudyEnrollmentRecommendation.reason optional

### DIFF
--- a/dto_model/src/main/scala/de/dnpm/dip/mtb/model/MTBRecommendations.scala
+++ b/dto_model/src/main/scala/de/dnpm/dip/mtb/model/MTBRecommendations.scala
@@ -206,7 +206,7 @@ final case class MTBStudyEnrollmentRecommendation
 (
   id: Id[MTBStudyEnrollmentRecommendation],
   patient: Reference[Patient],
-  reason: Reference[MTBDiagnosis],
+  reason: Option[Reference[MTBDiagnosis]],
   issuedOn: LocalDate,
   levelOfEvidence: Option[LevelOfEvidence],
   priority: Coding[Recommendation.Priority.Value],

--- a/generators/src/main/scala/de/dnpm/dip/mtb/gens/Generators.scala
+++ b/generators/src/main/scala/de/dnpm/dip/mtb/gens/Generators.scala
@@ -1150,7 +1150,7 @@ trait Generators
         } yield MTBStudyEnrollmentRecommendation(
           recId,
           patient,
-          medicationRecommendations.head.reason.get,
+          medicationRecommendations.head.reason,
           LocalDate.now,
           medicationRecommendations.head.levelOfEvidence,
           priority,


### PR DESCRIPTION
fix: Made MTBStudyEnrollmentRecommendation.reason optional, to be consistent with other MTBRecommendations

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Study enrollment recommendations now support optional diagnosis associations, enabling more flexible documentation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->